### PR TITLE
parse vfat super block

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,19 @@
 
 ## About
 
-`parti` shows partition table information for
+`parti` shows partition and file system details for
 
 * [Master Boot Record (MBR) Partition Table][mbr]
 * [GUID Partition Table (GPT)][gpt]
 * [Apple Partition Map][apm]
 * [El Torito Bootable CD/DVD][eltorito]
+* [FAT file system BPB][fat]
 
 [mbr]: https://en.wikipedia.org/wiki/Master_boot_record
 [gpt]: https://en.wikipedia.org/wiki/GUID_Partition_Table
 [apm]: https://en.wikipedia.org/wiki/Apple_Partition_Map
 [eltorito]: https://en.wikipedia.org/wiki/El_Torito_%28CD-ROM_standard%29
+[fat]: https://en.wikipedia.org/wiki/Design_of_the_FAT_file_system#BPB
 
 It shows the complete information but mostly in uninterpreted form (unlike
 partitioning tools like `fdisk` or `parted`).

--- a/parti.c
+++ b/parti.c
@@ -1504,8 +1504,6 @@ int fs_detail_fat(int indent, uint64_t sector)
   unsigned hidden, fat_secs, data_start, clusters, root_secs;
   unsigned drv_num;
 
-  indent += 2;
-
   if(opt.disk.block_size < 0x200) return 0;
 
   i = disk_read(buf, sector, 1);
@@ -1557,11 +1555,16 @@ int fs_detail_fat(int indent, uint64_t sector)
 
   drv_num = read_byte(buf + (bpb32 ? 64 : 36));
 
-  if(indent == 2) printf(SEP "\nfat fs:\n");
+  if(indent == 0) printf(SEP "\n");
+
+  printf("%*sfat%u:\n", indent, "", fat_bits);
+
+  indent += 2;
+
+  printf("%*ssector size: %u\n", indent, "", bytes_p_sec);
 
   printf(
-    "%*sfat%u bpb[%u], oem \"%s\", media 0x%02x, drive 0x%02x, hs %u/%u\n", indent, "",
-    fat_bits,
+    "%*sbpb[%u], oem \"%s\", media 0x%02x, drive 0x%02x, hs %u/%u\n", indent, "",
     bpb_len,
     cname(buf + 3, 8),
     read_byte(buf + 21),
@@ -1587,15 +1590,15 @@ int fs_detail_fat(int indent, uint64_t sector)
     );
   }
 
-  printf("%*sbytes per sector 0x%x, sectors per cluster %u\n", indent, "",
-    bytes_p_sec,
-    sec_p_cluster
-  );
-
-  printf("%*ssize %u, hidden %u, data start %u\n", indent, "",
+  printf("%*sfs size %u, hidden %u, data start %u\n", indent, "",
     sectors,
     hidden,
     data_start
+  );
+
+  printf("%*scluster size %u, clusters %u\n", indent, "",
+    sec_p_cluster,
+    clusters
   );
 
   printf("%*sfats %u, fat size %u, fat start %u\n", indent, "",

--- a/parti.c
+++ b/parti.c
@@ -184,6 +184,7 @@ char *iso_block_to_name(unsigned block);
 int fs_probe(uint64_t offset);
 void dump_zipl_components(uint64_t sec);
 void dump_zipl(void);
+int fs_detail_fat(int indent, uint64_t sector);
 
 
 struct option options[] = {
@@ -268,6 +269,7 @@ int main(int argc, char **argv)
   dump_apple_ptables();
   dump_eltorito();
   dump_zipl();
+  fs_detail_fat(0, 0);
 
   close(opt.disk.fd);
 
@@ -472,7 +474,14 @@ char *cname(void *buf, int len)
   memcpy(name, buf, len);
   name[len] = 0;
 
-  for(n = name, i = len - 1; i > 0 && !n[i]; i--);
+  for(n = name, i = len - 1; i >= 0; i--) {
+    if(n[i] == 0 || n[i] == 0x20 || n[i] == 0x09 || n[i] == 0x0a) {
+      n[i] = 0;
+    }
+    else {
+      break;
+    }
+  }
 
   return name;
 }
@@ -665,6 +674,8 @@ void print_ptable_entry(int nr, ptable_t *ptable)
       printf(", \"%s\"", s);
     }
     printf("\n");
+
+    fs_detail_fat(7, (unsigned long long) ptable->start.lin + ptable->base);
   }
 }
 
@@ -699,6 +710,13 @@ void dump_mbr_ptable()
     // printf("no mbr partition table\n");
     return;
   }
+
+  for(i = j = 0; i < 4 * 16; i++) {
+    j |= read_byte(buf + 0x1be + i);
+  }
+
+  // empty partition table
+  if(!j) return;
 
   parse_ptable(buf, 0x1be, ptable, 0, 0, 4);
   i = guess_geo(ptable, 4, &s, &h);
@@ -898,12 +916,11 @@ uint64_t dump_gpt_ptable(uint64_t addr)
     printf(", fs \"%s\"", fs.type ?: "unknown");
     if(fs.label) printf(", label \"%s\"", fs.label);
     if(fs.uuid) printf(", uuid \"%s\"", fs.uuid);
-
     if((s = iso_block_to_name(le64toh(p->first_lba)))) {
       printf(", \"%s\"", s);
     }
-
     printf("\n");
+
     if(opt.show.raw) {
       printf("       name_hex[%d]", name_len);
       n = p->name;
@@ -913,6 +930,7 @@ uint64_t dump_gpt_ptable(uint64_t addr)
       printf("\n");
     }
 
+    fs_detail_fat(7, (unsigned long long) le64toh(p->first_lba));
   }
 
   free(part0);
@@ -1155,6 +1173,8 @@ void dump_eltorito()
         printf("\n");
         s = cname(el->entry.name, sizeof el->entry.name);
         printf("       selection criteria 0x%02x \"%s\"\n", el->entry.criteria, s);
+
+        fs_detail_fat(7, (unsigned long long) le32toh(el->entry.start));
         break;
 
       case 0x90:
@@ -1472,5 +1492,131 @@ void dump_zipl()
     printf(", components:\n");
     dump_zipl_components(sec);
   }
+}
+
+
+int fs_detail_fat(int indent, uint64_t sector)
+{
+  unsigned char buf[opt.disk.block_size];
+  int i;
+  unsigned bpb_len, fat_bits, bpb32;
+  unsigned bytes_p_sec, sec_p_cluster, resvd_sec, fats, root_ents, sectors;
+  unsigned hidden, fat_secs, data_start, clusters, root_secs;
+  unsigned drv_num;
+
+  indent += 2;
+
+  if(opt.disk.block_size < 0x200) return 0;
+
+  i = disk_read(buf, sector, 1);
+
+  if(i || read_word_le(buf + 0x1fe) != 0xaa55) return 0;
+
+  if(read_byte(buf) == 0xeb) {
+    i = 2 + (int8_t) read_byte(buf + 1);
+  }
+  else if(read_byte(buf) == 0xe9) {
+    i = 3 + (int16_t) read_word_le(buf + 1);
+  }
+  else {
+    i = 0;
+  }
+
+  if(i < 3) return 0;
+
+  bpb_len = i;
+
+  if(!strcmp(cname(buf + 3, 8), "NTFS")) return 0;
+
+  bytes_p_sec = read_word_le(buf + 11);
+  sec_p_cluster = read_byte(buf + 13);
+  resvd_sec = read_word_le(buf + 14);
+  fats = read_byte(buf + 16);
+  root_ents = read_word_le(buf + 17);
+  sectors = read_word_le(buf + 19);
+  hidden = read_dword_le(buf + 28);
+  if(!sectors) sectors = read_dword_le(buf + 32);
+  fat_secs = read_word_le(buf + 22);
+  bpb32 = fat_secs ? 0 : 1;
+  if(bpb32) fat_secs = read_dword_le(buf + 36);
+
+  if(!sec_p_cluster || !fats) return 0;
+
+  // bytes_p_sec should be a power of 2 and > 0
+  if(!bytes_p_sec || (bytes_p_sec & (bytes_p_sec - 1))) return 0;
+
+  root_secs = (root_ents * 32 + bytes_p_sec - 1 ) / bytes_p_sec;
+
+  data_start = resvd_sec + fats * fat_secs + root_secs;
+
+  clusters = (sectors - data_start) / sec_p_cluster;
+
+  fat_bits = 12;
+  if(clusters >= 4085) fat_bits = 16;
+  if(clusters >= 65525) fat_bits = 32;
+
+  drv_num = read_byte(buf + (bpb32 ? 64 : 36));
+
+  if(indent == 2) printf(SEP "\nfat fs:\n");
+
+  printf(
+    "%*sfat%u bpb[%u], oem \"%s\", media 0x%02x, drive 0x%02x, hs %u/%u\n", indent, "",
+    fat_bits,
+    bpb_len,
+    cname(buf + 3, 8),
+    read_byte(buf + 21),
+    drv_num,
+    read_word_le(buf + 26),
+    read_word_le(buf + 24)
+  );
+
+  if(read_byte(buf + (bpb32 ? 66 : 38)) == 0x29) {
+    printf("%*svol id 0x%08x, label \"%s\"", indent, "",
+      read_dword_le(buf + (bpb32 ? 67 : 39)),
+      cname(buf + (bpb32 ? 71 : 43), 11)
+    );
+    printf(", fs type \"%s\"\n", cname(buf + (bpb32 ? 82 : 54), 8));
+  }
+
+  if(bpb32) {
+    printf("%*sextflags 0x%02x, fs ver %u.%u, fs info %u, backup bpb %u\n", indent, "",
+      read_byte(buf + 40),
+      read_byte(buf + 43), read_byte(buf + 42),
+      read_word_le(buf + 48),
+      read_word_le(buf + 50)
+    );
+  }
+
+  printf("%*sbytes per sector 0x%x, sectors per cluster %u\n", indent, "",
+    bytes_p_sec,
+    sec_p_cluster
+  );
+
+  printf("%*ssize %u, hidden %u, data start %u\n", indent, "",
+    sectors,
+    hidden,
+    data_start
+  );
+
+  printf("%*sfats %u, fat size %u, fat start %u\n", indent, "",
+    fats,
+    fat_secs,
+    resvd_sec
+  );
+
+  if(bpb32) {
+    printf("%*sroot cluster %u\n", indent, "",
+      read_dword_le(buf + 44)
+    );
+  }
+  else {
+    printf("%*sroot entries %u, root size %u, root start %u\n", indent, "",
+      root_ents,
+      root_secs,
+      resvd_sec + fats * fat_secs
+    );
+  }
+
+  return 1;
 }
 

--- a/parti.c
+++ b/parti.c
@@ -1471,6 +1471,13 @@ void dump_zipl()
 }
 
 
+/*
+ * Print fat file system details.
+ *
+ * The fs starts at sector (sector size is opt.disk.block_size).
+ * The output is indented by 'indent' spaces.
+ * If indent is 0, prints also a separator line.
+ */
 int fs_detail_fat(int indent, uint64_t sector)
 {
   unsigned char buf[opt.disk.block_size];
@@ -1600,6 +1607,13 @@ int fs_detail_fat(int indent, uint64_t sector)
 }
 
 
+/*
+ * Print file system details.
+ *
+ * The fs starts at sector (sector size is opt.disk.block_size).
+ * The output is indented by 'indent' spaces.
+ * If indent is 0, prints also a separator line.
+ */
 int fs_detail(int indent, uint64_t sector)
 {
   char *s;
@@ -1627,6 +1641,9 @@ int fs_detail(int indent, uint64_t sector)
 }
 
 
+/*
+ * Print file name and size.
+ */
 void disk_detail()
 {
   struct stat sbuf;


### PR DESCRIPTION
This adds support for detecting and parsing FAT12/16/32 file system info.

For technical reference, see e.g. https://en.wikipedia.org/wiki/Design_of_the_FAT_file_system.