### PR TITLE
Use standard location for isoinfo binary

### DIFF
--- a/parti.c
+++ b/parti.c
@@ -1197,7 +1197,7 @@ void read_isoinfo()
 
   if(!fs_probe(0)) return;
 
-  asprintf(&cmd, "/usr/lib/genisoimage/isoinfo -R -l -i %s 2>/dev/null", opt.disk.name);
+  asprintf(&cmd, "/usr/bin/isoinfo -R -l -i %s 2>/dev/null", opt.disk.name);
 
   if((p = popen(cmd, "r"))) {
     while(getline(&line, &line_len, p) != -1) {


### PR DESCRIPTION
isoinfo is provided by both mkisofs (from cdrtools) and by
cdrkit-cdrtools-compat (from wodim). There is no reason
to hardcode wodim.

Wodim is going to be removed since it's unmaintained and it
adds no functionality over cdrtools.
