### PR TITLE
notify about invalid MBR partition entries (bsc#1178691)

### DIFF
--- a/parti.c
+++ b/parti.c
@@ -37,6 +37,7 @@ typedef struct {
   unsigned type;
   unsigned boot:1;
   unsigned valid:1;
+  unsigned empty:1;
   struct {
     unsigned c, h, s, lin;
   } start;
@@ -558,6 +559,9 @@ void parse_ptable(void *buf, unsigned addr, ptable_t *ptable, unsigned base, uns
 
   for(; entries; entries--, addr += 0x10, ptable++) {
     ptable->idx = 4 - entries + 1;
+    if(read_qword_le(buf + addr) == 0 && read_qword_le(buf + addr + 0x8) == 0) {
+      ptable->empty = 1;
+    }
     u = read_byte(buf + addr);
     if(u & 0x7f) continue;
     ptable->boot = u >> 7;
@@ -677,6 +681,9 @@ void print_ptable_entry(int nr, ptable_t *ptable)
     if(s) printf(" (%s)", s);
     printf("\n");
     fs_detail(7, (unsigned long long) ptable->start.lin + ptable->base);
+  }
+  else if(!ptable->empty) {
+    printf("  %-3d  invalid data\n", nr);
   }
 }
 


### PR DESCRIPTION
## Issue

- https://bugzilla.suse.com/show_bug.cgi?id=1178691

Do not just ignore invalid MBR partition table entries. Instead, label them as invalid.

## Example output

```
# parti test.iso 
test.iso: 8106840 sectors
- - - - - - - - - - - - - - - -
mbr id: 0xbabababa
  sector size: 512
  mbr partition table (chs 504/255/63, inconsistent geo):
  1  * 0 - 8106239 (size 8106240), chs 1023/255/63 - 1023/255/63
       type 0x96 (chrp iso9660)
       fs "iso9660", label "SLE-12-SP4-Server-DVD-ppc64le045", uuid "2018-11-07-14-08-32-00"
  2    invalid data
  3    invalid data
  4    invalid data
```