### PR TITLE
add unify-gpt tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PARTI_H = $(PARTI_SRC:.c=.h)
 
 .PHONY: all install archive clean
 
-all: changelog parti
+all: changelog parti unify-gpt
 
 changelog: $(GITDEPS)
 	$(GIT2LOG) --changelog changelog
@@ -29,8 +29,12 @@ $(PARTI_OBJ) parti.o: %.o: %.c $(PARTI_H)
 parti: parti.o $(PARTI_OBJ)
 	$(CC) $^ $(LDFLAGS) -o $@
 
+unify-gpt: unify-gpt.o
+	$(CC) $^ -o $@
+
 install: parti
 	install -m 755 -D parti $(DESTDIR)$(BINDIR)/parti
+	install -m 755 -D unify-gpt $(DESTDIR)$(BINDIR)/unify-gpt
 
 archive: changelog
 	mkdir -p package
@@ -39,5 +43,5 @@ archive: changelog
 	xz -f package/$(PREFIX).tar
 
 clean:
-	rm -f *~ *.o parti changelog VERSION
+	rm -f *~ *.o parti unify-gpt changelog VERSION
 	rm -rf package

--- a/obs/parti.spec
+++ b/obs/parti.spec
@@ -60,6 +60,7 @@ make DESTDIR=%{buildroot} install %{?_smp_mflags}
 %files
 %defattr(-,root,root)
 %{_bindir}/parti
+%{_bindir}/unify-gpt
 %doc README.md COPYING
 
 %changelog

--- a/ptable_gpt.c
+++ b/ptable_gpt.c
@@ -482,6 +482,7 @@ void dump_gpt_ptables(disk_t *disk)
     if(!u) continue;
     dump_gpt_ptable(disk, u);
 
-    return;
+    // json format can hold only one gpt
+    if(opt.json) return;
   }
 }

--- a/unify-gpt.c
+++ b/unify-gpt.c
@@ -1,0 +1,478 @@
+#define _GNU_SOURCE
+#define _FILE_OFFSET_BITS 64
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <getopt.h>
+#include <string.h>
+#include <inttypes.h>
+#include <fcntl.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/ioctl.h>
+#include <sys/syscall.h>
+#include <uuid/uuid.h>
+
+#ifndef VERSION
+#define VERSION "0.0"
+#endif
+
+/*
+  This is really experimental.
+  
+  The code adjusts only the primary GPT, the backup GPT will be invalid.
+
+  That's usually not a problem and fdisk/parted can sync both. Also, usually
+  only the primary GPT is used (as long as it is valid).
+
+  If it turns out to be useful, the code can be enhanced to produce also a
+  correct backup GPT.
+
+  The code also reduces the number of partitions to 24 (4k case) resp. 8 (2k case).
+*/
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+void help(void);
+int unify_gpt(char *device);
+
+struct option options[] = {
+  { "2k",          0, NULL, 1001  },
+  { "4k",          0, NULL, 1002  },
+  { "version",     0, NULL, 1003  },
+  { "help",        0, NULL, 'h'  },
+  { }
+};
+
+struct {
+  unsigned _2k:1;
+  unsigned _4k:1;
+  unsigned verbose;
+} opt;
+
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+#define GPT_SIGNATURE   0x5452415020494645ll
+
+typedef struct {
+  uint64_t signature;
+  uint32_t revision;
+  uint32_t header_size;
+  uint32_t header_crc;
+  uint32_t reserved;
+  uint64_t current_lba;
+  uint64_t backup_lba;
+  uint64_t first_lba;
+  uint64_t last_lba;
+  uuid_t disk_guid;
+  uint64_t partition_lba;
+  uint32_t partition_entries;
+  uint32_t partition_entry_size;
+  uint32_t partition_crc;
+} gpt_header_t;
+
+typedef struct {
+  uuid_t type_guid;
+  uuid_t partition_guid;
+  uint64_t first_lba;
+  uint64_t last_lba;
+  uint64_t attributes;
+  uint16_t name[36];
+} gpt_entry_t;
+
+uint32_t chksum_crc32(void *buf, unsigned len);
+uint8_t read_byte(void *buf);
+uint16_t read_word_le(void *buf);
+uint16_t read_word_be(void *buf);
+uint32_t read_dword_le(void *buf);
+uint32_t read_dword_be(void *buf);
+uint64_t read_qword_le(void *buf);
+uint64_t read_qword_be(void *buf);
+
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+int main(int argc, char **argv)
+{
+  int i;
+  extern int optind;
+  extern int opterr;
+
+  opterr = 0;
+
+  while((i = getopt_long(argc, argv, "h", options, NULL)) != -1) {
+    switch(i) {
+      case 1001:
+        opt._2k = 1;
+        break;
+
+      case 1002:
+        opt._4k = 1;
+        break;
+
+      case 1003:
+        printf(VERSION "\n");
+        return 0;
+        break;
+
+      default:
+        help();
+        return i == 'h' ? 0 : 1;
+    }
+  }
+
+  argc -= optind;
+  argv += optind;
+
+  if(argc != 1) {
+    help();
+    return 1;
+  }
+
+  if(opt._2k && opt._4k) {
+    fprintf(stderr, "Must use either --2k or --4k.\n");
+    return 1;
+  }
+
+  return unify_gpt(argv[0]);
+}
+
+
+void help()
+{
+  fprintf(stderr,
+    "Usage: unify-gpt [OPTIONS] DISK_DEVICE\n"
+    "Create a unified GPT for two different block sizes.\n"
+    "\n"
+    "Options:\n"
+    "  --2k                Add GPT for 2k block size.\n"
+    "  --4k                Add GPT for 4k block size.\n"
+    "  --version           Show version.\n"
+    "  --help              Print this help text.\n"
+    "\n"
+    "This tool takes a disk with a valid 0.5k block size GPT\n"
+    "and adds a valid GPT for 2k or 4k on top of that.\n"
+    "\n"
+    "Existing partition entries (up to 8 for 2k, up to 24 for 4k)\n"
+    "are kept. Partitions should be aligned to 2k/4k block size to\n"
+    "make this work.\n"
+    "\n"
+    "The created GPT will not have the default layout (that is, 128\n"
+    "partitions max, free space starting at block 34) and you might\n"
+    "see warnings about this when using it. But in general it should\n"
+    "work just fine\n"
+  );
+}
+
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+int unify_gpt(char *device)
+{
+  int fd;
+  uint8_t gpt_1[33 * 512];
+  uint8_t gpt_2[33 * 512];
+  gpt_header_t *gpt1, *gpt2;
+  uint64_t gpt1_backup_lba, gpt2_backup_lba;
+  uint32_t crc32, orig_crc32;
+
+  fd = open(device, O_RDWR | O_LARGEFILE);
+  if(fd == -1) {
+    perror(device);
+    return 1;
+  }
+
+  if(lseek(fd, 512, SEEK_SET) != 512) {
+    perror(device);
+    return 1;
+  }
+
+  if(read(fd, gpt_1, sizeof gpt_1) != sizeof gpt_1) {
+    perror(device);
+    return 1;
+  }
+
+  gpt1 = (gpt_header_t *) gpt_1;
+
+  if(le64toh(gpt1->signature) != GPT_SIGNATURE) {
+    fprintf(stderr, "no GPT signature\n");
+    return 1;
+  }
+
+  gpt1_backup_lba = le64toh(gpt1->backup_lba);
+
+  if(lseek(fd, (gpt1_backup_lba - 32) * 512, SEEK_SET) != (gpt1_backup_lba - 32) * 512) {
+    perror(device);
+    return 1;
+  }
+
+  if(read(fd, gpt_2, sizeof gpt_2) != sizeof gpt_2) {
+    perror(device);
+    return 1;
+  }
+
+  gpt2 = (gpt_header_t *) (gpt_2 + 32 * 512);
+
+  if(le64toh(gpt2->signature) != GPT_SIGNATURE) {
+    fprintf(stderr, "no backup GPT signature\n");
+    return 1;
+  }
+
+  gpt2_backup_lba = le64toh(gpt2->backup_lba);
+  if(gpt2_backup_lba != 1) {
+    perror("backup GPT does not refer back to primary\n");
+    return 1;
+  }
+
+  if((gpt1_backup_lba & 7) != 7) {
+    fprintf(stderr, "backup GPT is not 4k aligned\n");
+    return 1;
+  }
+
+  orig_crc32 = gpt1->header_crc;
+  gpt1->header_crc = 0;
+  crc32 = chksum_crc32(gpt1, le32toh(gpt1->header_size));
+  gpt1->header_crc = orig_crc32;
+  if(crc32 != gpt1->header_crc) {
+    fprintf(stderr, "GTP header checksum wrong\n");
+    return 1;
+  }
+
+  // reduce 0.5k variant
+  unsigned entries = opt._2k ? 8 : 24;
+
+  gpt1->partition_entries = le32toh(entries);
+  gpt1->first_lba = le32toh(opt._4k ? 3 * 8 : 3 * 4);
+
+  gpt1->partition_crc = le32toh(chksum_crc32(gpt_1 + 2*512 - 512, entries*128));
+
+  gpt1->header_crc = 0;
+  crc32 = chksum_crc32(gpt1, le32toh(gpt1->header_size));
+  gpt1->header_crc = le32toh(crc32);
+
+  // add 2k
+  if(opt._2k) {
+    memcpy(gpt_1 + 2048 - 512, gpt_1, 92);
+    memcpy(gpt_1 + 2*2048 - 512, gpt_1 + 512, 128*entries);
+
+    gpt1 = (gpt_header_t *) (gpt_1 + 2048 - 512);
+
+    gpt1->partition_entries = le32toh(entries);
+    gpt1->first_lba = le32toh(3);
+    gpt1->last_lba = le32toh((gpt1->last_lba + 1) / 4 - 1);
+
+    gpt_entry_t *gpt_entry = (gpt_entry_t *) &gpt_1[2*2048 - 512];
+
+    for(unsigned u = 0 ; u < entries; u++) {
+      if(!gpt_entry[u].first_lba || !gpt_entry[u].last_lba) break;
+      if(gpt_entry[u].first_lba & 3) {
+        fprintf(stderr, "entry %u: start not 2k aligned\n", u);
+        return 1;
+      }
+      gpt_entry[u].first_lba = gpt_entry[u].first_lba / 4;
+
+      if((gpt_entry[u].last_lba + 1) & 3) {
+        fprintf(stderr, "entry %u: end not 2k aligned\n", u);
+        return 1;
+      }
+      gpt_entry[u].last_lba = (gpt_entry[u].last_lba + 1) / 4 - 1;
+    }
+
+    gpt1->backup_lba = (gpt1->backup_lba + 1) / 4 - 1;
+
+    gpt1->partition_crc = le32toh(chksum_crc32(gpt_1 + 2*2048 - 512, entries*128));
+
+    gpt1->header_crc = 0;
+    crc32 = chksum_crc32(gpt1, le32toh(gpt1->header_size));
+    gpt1->header_crc = le32toh(crc32);
+  }
+
+
+  // add 4k
+  if(opt._4k) {
+    memcpy(gpt_1 + 4096 - 512, gpt_1, 92);
+    memcpy(gpt_1 + 2*4096 - 512, gpt_1 + 512, 128*entries);
+
+    gpt1 = (gpt_header_t *) (gpt_1 + 4096 - 512);
+
+    gpt1->partition_entries = le32toh(entries);
+    gpt1->first_lba = le32toh(3);
+    gpt1->last_lba = le32toh((gpt1->last_lba + 1) / 8 - 1);
+
+    gpt_entry_t *gpt_entry = (gpt_entry_t *) &gpt_1[2*4096 - 512];
+
+    for(unsigned u = 0 ; u < entries; u++) {
+      if(!gpt_entry[u].first_lba || !gpt_entry[u].last_lba) break;
+      if(gpt_entry[u].first_lba & 7) {
+        fprintf(stderr, "entry %u: start not 4k aligned\n", u);
+        return 1;
+      }
+      gpt_entry[u].first_lba = gpt_entry[u].first_lba / 8;
+
+      if((gpt_entry[u].last_lba + 1) & 7) {
+        fprintf(stderr, "entry %u: end not 4k aligned\n", u);
+        return 1;
+      }
+      gpt_entry[u].last_lba = (gpt_entry[u].last_lba + 1) / 8 - 1;
+    }
+
+    gpt1->backup_lba = (gpt1->backup_lba + 1) / 8 - 1;
+
+    gpt1->partition_crc = le32toh(chksum_crc32(gpt_1 + 2*4096 - 512, entries*128));
+
+    gpt1->header_crc = 0;
+    crc32 = chksum_crc32(gpt1, le32toh(gpt1->header_size));
+    gpt1->header_crc = le32toh(crc32);
+  }
+
+
+
+#if 1
+  if(lseek(fd, 512, SEEK_SET) != 512) {
+    perror(device);
+    return 1;
+  }
+
+  if(write(fd, gpt_1, sizeof gpt_1) != sizeof gpt_1) {
+    perror(device);
+    return 1;
+  }
+#endif
+
+  close(fd);
+
+  return 0;
+}
+
+
+// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+uint32_t chksum_crc32(void *buf, unsigned len)
+{
+  static uint32_t crc_tab[256] = {
+    0,          0x77073096, 0xee0e612c, 0x990951ba,
+    0x076dc419, 0x706af48f, 0xe963a535, 0x9e6495a3,
+    0x0edb8832, 0x79dcb8a4, 0xe0d5e91e, 0x97d2d988,
+    0x09b64c2b, 0x7eb17cbd, 0xe7b82d07, 0x90bf1d91,
+    0x1db71064, 0x6ab020f2, 0xf3b97148, 0x84be41de,
+    0x1adad47d, 0x6ddde4eb, 0xf4d4b551, 0x83d385c7,
+    0x136c9856, 0x646ba8c0, 0xfd62f97a, 0x8a65c9ec,
+    0x14015c4f, 0x63066cd9, 0xfa0f3d63, 0x8d080df5,
+    0x3b6e20c8, 0x4c69105e, 0xd56041e4, 0xa2677172,
+    0x3c03e4d1, 0x4b04d447, 0xd20d85fd, 0xa50ab56b,
+    0x35b5a8fa, 0x42b2986c, 0xdbbbc9d6, 0xacbcf940,
+    0x32d86ce3, 0x45df5c75, 0xdcd60dcf, 0xabd13d59,
+    0x26d930ac, 0x51de003a, 0xc8d75180, 0xbfd06116,
+    0x21b4f4b5, 0x56b3c423, 0xcfba9599, 0xb8bda50f,
+    0x2802b89e, 0x5f058808, 0xc60cd9b2, 0xb10be924,
+    0x2f6f7c87, 0x58684c11, 0xc1611dab, 0xb6662d3d,
+    0x76dc4190, 0x01db7106, 0x98d220bc, 0xefd5102a,
+    0x71b18589, 0x06b6b51f, 0x9fbfe4a5, 0xe8b8d433,
+    0x7807c9a2, 0x0f00f934, 0x9609a88e, 0xe10e9818,
+    0x7f6a0dbb, 0x086d3d2d, 0x91646c97, 0xe6635c01,
+    0x6b6b51f4, 0x1c6c6162, 0x856530d8, 0xf262004e,
+    0x6c0695ed, 0x1b01a57b, 0x8208f4c1, 0xf50fc457,
+    0x65b0d9c6, 0x12b7e950, 0x8bbeb8ea, 0xfcb9887c,
+    0x62dd1ddf, 0x15da2d49, 0x8cd37cf3, 0xfbd44c65,
+    0x4db26158, 0x3ab551ce, 0xa3bc0074, 0xd4bb30e2,
+    0x4adfa541, 0x3dd895d7, 0xa4d1c46d, 0xd3d6f4fb,
+    0x4369e96a, 0x346ed9fc, 0xad678846, 0xda60b8d0,
+    0x44042d73, 0x33031de5, 0xaa0a4c5f, 0xdd0d7cc9,
+    0x5005713c, 0x270241aa, 0xbe0b1010, 0xc90c2086,
+    0x5768b525, 0x206f85b3, 0xb966d409, 0xce61e49f,
+    0x5edef90e, 0x29d9c998, 0xb0d09822, 0xc7d7a8b4,
+    0x59b33d17, 0x2eb40d81, 0xb7bd5c3b, 0xc0ba6cad,
+    0xedb88320, 0x9abfb3b6, 0x03b6e20c, 0x74b1d29a,
+    0xead54739, 0x9dd277af, 0x04db2615, 0x73dc1683,
+    0xe3630b12, 0x94643b84, 0x0d6d6a3e, 0x7a6a5aa8,
+    0xe40ecf0b, 0x9309ff9d, 0x0a00ae27, 0x7d079eb1,
+    0xf00f9344, 0x8708a3d2, 0x1e01f268, 0x6906c2fe,
+    0xf762575d, 0x806567cb, 0x196c3671, 0x6e6b06e7,
+    0xfed41b76, 0x89d32be0, 0x10da7a5a, 0x67dd4acc,
+    0xf9b9df6f, 0x8ebeeff9, 0x17b7be43, 0x60b08ed5,
+    0xd6d6a3e8, 0xa1d1937e, 0x38d8c2c4, 0x4fdff252,
+    0xd1bb67f1, 0xa6bc5767, 0x3fb506dd, 0x48b2364b,
+    0xd80d2bda, 0xaf0a1b4c, 0x36034af6, 0x41047a60,
+    0xdf60efc3, 0xa867df55, 0x316e8eef, 0x4669be79,
+    0xcb61b38c, 0xbc66831a, 0x256fd2a0, 0x5268e236,
+    0xcc0c7795, 0xbb0b4703, 0x220216b9, 0x5505262f,
+    0xc5ba3bbe, 0xb2bd0b28, 0x2bb45a92, 0x5cb36a04,
+    0xc2d7ffa7, 0xb5d0cf31, 0x2cd99e8b, 0x5bdeae1d,
+    0x9b64c2b0, 0xec63f226, 0x756aa39c, 0x026d930a,
+    0x9c0906a9, 0xeb0e363f, 0x72076785, 0x05005713,
+    0x95bf4a82, 0xe2b87a14, 0x7bb12bae, 0x0cb61b38,
+    0x92d28e9b, 0xe5d5be0d, 0x7cdcefb7, 0x0bdbdf21,
+    0x86d3d2d4, 0xf1d4e242, 0x68ddb3f8, 0x1fda836e,
+    0x81be16cd, 0xf6b9265b, 0x6fb077e1, 0x18b74777,
+    0x88085ae6, 0xff0f6a70, 0x66063bca, 0x11010b5c,
+    0x8f659eff, 0xf862ae69, 0x616bffd3, 0x166ccf45,
+    0xa00ae278, 0xd70dd2ee, 0x4e048354, 0x3903b3c2,
+    0xa7672661, 0xd06016f7, 0x4969474d, 0x3e6e77db,
+    0xaed16a4a, 0xd9d65adc, 0x40df0b66, 0x37d83bf0,
+    0xa9bcae53, 0xdebb9ec5, 0x47b2cf7f, 0x30b5ffe9,
+    0xbdbdf21c, 0xcabac28a, 0x53b39330, 0x24b4a3a6,
+    0xbad03605, 0xcdd70693, 0x54de5729, 0x23d967bf,
+    0xb3667a2e, 0xc4614ab8, 0x5d681b02, 0x2a6f2b94,
+    0xb40bbe37, 0xc30c8ea1, 0x5a05df1b, 0x2d02ef8d
+  };
+
+  uint32_t crc;
+  unsigned u;
+  unsigned char *p = buf;
+
+  for(u = 0, crc = 0xffffffff; u < len; u++) {
+    crc = crc_tab[(uint8_t) crc ^ *p++] ^ (crc >> 8);
+  }
+
+  return crc ^ 0xffffffff;
+}
+
+
+uint8_t read_byte(void *buf)
+{
+  unsigned char *b = buf;
+
+  return b[0];
+}
+
+
+uint16_t read_word_le(void *buf)
+{
+  unsigned char *b = buf;
+
+  return (b[1] << 8) + b[0];
+}
+
+
+uint16_t read_word_be(void *buf)
+{
+  unsigned char *b = buf;
+
+  return (b[0] << 8) + b[1];
+}
+
+
+uint32_t read_dword_le(void *buf)
+{
+  unsigned char *b = buf;
+
+  return (b[3] << 24) + (b[2] << 16) + (b[1] << 8) + b[0];
+}
+
+
+uint32_t read_dword_be(void *buf)
+{
+  unsigned char *b = buf;
+
+  return (b[0] << 24) + (b[1] << 16) + (b[2] << 8) + b[3];
+}
+
+
+uint64_t read_qword_le(void *buf)
+{
+  return ((uint64_t) read_dword_le(buf + 4) << 32) + read_dword_le(buf);
+}
+
+
+uint64_t read_qword_be(void *buf)
+{
+  return ((uint64_t) read_dword_be(buf) << 32) + read_dword_be(buf + 4);
+}
+


### PR DESCRIPTION
## Task

This add a `unify-gpt` tool that can produce a GPT which is valid with (two) different block sizes.

These will be 512 bytes vs. 4 kiB usually - but any block size  that differs at least by a factor 4 should work.

Both GPT variants describe exacty the same partition layout.

The use case is to have an image file that can equally be used with 4 kiB as with 512 byte block size disks.

## Todo

The backup GPT is not yet updated.